### PR TITLE
[IT-2768] Update role name for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
       CONTEXT_1KD: 1kd-dev
       CONTEXT_PEC: pec-dev
       CONTEXT_AMP: amp-ad-dev
-      ROLE_TO_ASSUME: arn:aws:iam::634210816736:role/sagebase-github-oidc-sage-ProviderRoledccmonitorEC-XDCFYUHLM75G
+      ROLE_TO_ASSUME: arn:aws:iam::634210816736:role/sagebase-github-oidc-sage-ProviderRole
 
   cdk-deploy-prod:
     if: ${{github.ref == 'refs/heads/prod'}}
@@ -81,4 +81,4 @@ jobs:
       CONTEXT_1KD: 1kd-prod
       CONTEXT_PEC: pec-prod
       CONTEXT_AMP: amp-ad-prod
-      ROLE_TO_ASSUME: arn:aws:iam::593604776210:role/sagebase-github-oidc-sage-ProviderRoledccmonitorEC-14DMJY7NRWMTG
+      ROLE_TO_ASSUME: arn:aws:iam::593604776210:role/sagebase-github-oidc-sage-ProviderRole

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
       CONTEXT_1KD: 1kd-dev
       CONTEXT_PEC: pec-dev
       CONTEXT_AMP: amp-ad-dev
-      ROLE_TO_ASSUME: arn:aws:iam::634210816736:role/sagebase-github-oidc-sage-ProviderRole
+      ROLE_TO_ASSUME: arn:aws:iam::634210816736:role/sagebase-github-oidc-sage-bionetworks-dccmonitor-infra
 
   cdk-deploy-prod:
     if: ${{github.ref == 'refs/heads/prod'}}
@@ -81,4 +81,4 @@ jobs:
       CONTEXT_1KD: 1kd-prod
       CONTEXT_PEC: pec-prod
       CONTEXT_AMP: amp-ad-prod
-      ROLE_TO_ASSUME: arn:aws:iam::593604776210:role/sagebase-github-oidc-sage-ProviderRole
+      ROLE_TO_ASSUME: arn:aws:iam::593604776210:role/sagebase-github-oidc-sage-bionetworks-dccmonitor-infra


### PR DESCRIPTION
The CI role names to assume will change due to PR
Sage-Bionetworks-IT/organizations-infra#859. update to the new role names

depends on Sage-Bionetworks-IT/organizations-infra#859

